### PR TITLE
Fixed the sentry tags in raven-lua and also add raven-lua version

### DIFF
--- a/raven.lua
+++ b/raven.lua
@@ -485,7 +485,7 @@ function _M.gen_capture_err(self)
 end
 
 -- HTTP request template
-local xsentryauth_http = "POST %s HTTP/1.0\r\nHost: %s\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: %d\r\nUser-Agent: %s\r\nX-Sentry-Auth: Sentry sentry_version=7, sentry_client=%s, sentry_timestamp=%s, sentry_key=%s, sentry_secret=%s\r\n\r\n%s"
+local xsentryauth_http = "POST %s HTTP/1.0\r\nHost: %s\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: %d\r\nUser-Agent: %s\r\nX-Sentry-Auth: Sentry sentry_version=6, sentry_client=%s, sentry_timestamp=%s, sentry_key=%s, sentry_secret=%s\r\n\r\n%s"
 
 -- http_send_core: do the actual network send. Expects an already
 -- connected socket.

--- a/raven.lua
+++ b/raven.lua
@@ -29,6 +29,7 @@ local setmetatable = setmetatable
 local tostring = tostring
 local xpcall = xpcall
 
+local version        = "0.4.1"
 local os_date        = os.date
 local os_time        = os.time
 local debug_getinfo  = debug.getinfo
@@ -235,13 +236,13 @@ function _M.new(self, dsn, conf)
       return nil, err
    end
 
-   obj.client_id = "raven-lua/0.4"
+   obj.client_id = "raven-lua/" .. version
    -- default level "error"
    obj.level = "error"
 
    if conf then
       if conf.tags then
-         obj.tags = { conf.tags }
+         obj.tags = conf.tags
       end
 
       if conf.logger then
@@ -373,9 +374,9 @@ function _M.send_report(self, json, conf)
    if conf then
       if conf.tags then
          if not json.tags then
-            json.tags = { conf.tags }
+            json.tags = conf.tags
          else
-            json.tags[#json.tags + 1] = conf.tags
+            for k,v in pairs(conf.tags) do json.tags[k] = v end
          end
       end
 
@@ -484,7 +485,7 @@ function _M.gen_capture_err(self)
 end
 
 -- HTTP request template
-local xsentryauth_http = "POST %s HTTP/1.0\r\nHost: %s\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: %d\r\nUser-Agent: %s\r\nX-Sentry-Auth: Sentry sentry_version=5, sentry_client=%s, sentry_timestamp=%s, sentry_key=%s, sentry_secret=%s\r\n\r\n%s"
+local xsentryauth_http = "POST %s HTTP/1.0\r\nHost: %s\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: %d\r\nUser-Agent: %s\r\nX-Sentry-Auth: Sentry sentry_version=7, sentry_client=%s, sentry_timestamp=%s, sentry_key=%s, sentry_secret=%s\r\n\r\n%s"
 
 -- http_send_core: do the actual network send. Expects an already
 -- connected socket.

--- a/tests/test_http.lua
+++ b/tests/test_http.lua
@@ -98,8 +98,8 @@ function test_capture_message()
       -- Example timestamp: 2014-03-07T00:17:47
       assert_not_nil(string_match(json.timestamp, "%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%d"))
       assert_not_nil(string_match(json.event_id, "%x+"))
-      assert_equal(1, #json.tags)
-      assert_equal("bar", json.tags[1].foo)
+      assert_not_nil(json.tags)
+      assert_equal("bar", json.tags.foo)
       posix.wait(cpid)
    end
 end
@@ -128,8 +128,8 @@ function test_capture_exception()
       -- Example timestamp: 2014-03-07T00:17:47
       assert_not_nil(string_match(json.timestamp, "%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%d"))
       assert_not_nil(string_match(json.event_id, "%x+"))
-      assert_equal(1, #json.tags)
-      assert_equal("bar", json.tags[1].foo)
+      assert_not_nil(json.tags)
+      assert_equal("bar", json.tags.foo)
       posix.wait(cpid)
    end
 end

--- a/tests/test_sanity.lua
+++ b/tests/test_sanity.lua
@@ -25,7 +25,7 @@ end
 function test_new()
    local rvn, msg = raven:new("https://public:secret@example.com/sentry/project-id")
    assert_not_nil(rvn)
-   assert_equal("raven-lua/0.4", rvn.client_id)
+   assert_equal("raven-lua/0.4.1", rvn.client_id)
 
    -- missing public key in DSN
    local rvn1, msg = raven:new("https://secret@example.com/sentry/project-id")
@@ -42,10 +42,10 @@ end
 function test_new2()
    local rvn, msg = raven:new("https://public:secret@example.com/sentry/project-id", { tags = { foo = "bar", abc = "def" }, logger = "myLogger" })
    assert_not_nil(rvn)
-   assert_equal("raven-lua/0.4", rvn.client_id)
+   assert_equal("raven-lua/0.4.1", rvn.client_id)
    assert_equal("myLogger", rvn.logger)
-   assert_equal("bar", rvn.tags[1].foo)
-   assert_equal("def", rvn.tags[1].abc)
+   assert_equal("bar", rvn.tags.foo)
+   assert_equal("def", rvn.tags.abc)
 end
 
 function test_new3()


### PR DESCRIPTION
The sentry context tags table structure might have been changed since last time raven-lua was released.

Fix the error on the Sentry on-premise and add [the current sentry protocol version, which is '7'](https://docs.getsentry.com/on-premise/clientdev/#authentication) and client version in the signature.

All unit tests passed and running against an on-premise Sentry backend gets corrected results on tags now.

This should resolve #12 
