### PR TITLE
Added lua-resty-http as sender

### DIFF
--- a/raven-lua-scm-1.rockspec
+++ b/raven-lua-scm-1.rockspec
@@ -15,6 +15,7 @@ to Sentry.]],
 dependencies = {
   "lua >= 5.1",
   "lua-cjson",
+  "lua-resty-http"
 }
 build = {
    type = "builtin",

--- a/raven/senders/lua-resty-http.lua
+++ b/raven/senders/lua-resty-http.lua
@@ -1,0 +1,77 @@
+-- vim: st=4 sts=4 sw=4 et:
+--- Network backend using [lua-resty-http](https://github.com/ledgetech/lua-resty-http).
+--- Supports https, http, and keepalive for better performance.
+--
+-- @module raven.senders.lua-resty-http
+-- @copyright 2014-2017 CloudFlare, Inc.
+-- @license BSD 3-clause (see LICENSE file)
+
+local util = require 'raven.util'
+local http = require 'resty.http'
+
+local tostring = tostring
+local cjson_encode = cjson.encode
+local pairs = pairs
+local setmetatable = setmetatable
+local table_concat = table.concat
+local parse_dsn = util.parse_dsn
+local generate_auth_header = util.generate_auth_header
+local _VERSION = util._VERSION
+local _M = {}
+
+local mt = {}
+mt.__index = mt
+
+function mt:send(json_str)
+    local httpc = http.new()
+    local res, err = httpc:request_uri(self.server, {
+        method = "POST",
+        headers = {
+            ['Content-Type'] = 'applicaion/json',
+            ['User-Agent'] = "raven-lua-http/" .. _VERSION,
+            ['X-Sentry-Auth'] = generate_auth_header(self),
+            ["Content-Length"] = tostring(#json_str),
+        },
+        body = cjson_encode(json_str),
+        keepalive = self.opts.keepalive,
+        keepalive_timeout = self.opts.keepalive_timeout,
+        keepalive_pool = self.opts.keepalive_pool
+    })
+
+    if not res then
+        return nil, table_concat(res)
+    end
+
+    return true
+end
+
+--- Configuration table for the nginx sender.
+-- @field dsn DSN string
+-- @field verify_ssl Whether or not the SSL certificate is checked (boolean,
+--  defaults to false)
+-- @field cafile Path to a CA bundle (see the `cafile` parameter in the
+--  [newcontext](https://github.com/brunoos/luasec/wiki/LuaSec-0.6#ssl_newcontext)
+--  docs)
+-- @table sender_conf
+
+--- Create a new sender object for the given DSN
+-- @param conf Configuration table, see @{sender_conf}
+-- @return A sender object
+function _M.new(conf)
+    local obj, err = parse_dsn(conf.dsn)
+    if not obj then
+        return nil, err
+    end
+
+    obj.opts = {
+        verify = conf.verify_ssl or false,
+        keepalive = conf.keepalive or false,
+        keepalive_timeout = conf.keepalive_timeout or 0,
+        keepalive_pool = conf.keepalive_pool or 0
+    }
+
+    return setmetatable(obj, mt)
+end
+
+return _M
+


### PR DESCRIPTION
I have added [lua-resty-http](https://github.com/ledgetech/lua-resty-http) as a sender. I was essentially having the same problem as issue https://github.com/cloudflare/raven-lua/issues/30.

The author of the previously mentioned issue did create his/her own pull request to add lua-resty-http as a sender, but the solution was very messy. My module is modeled after the luasocket module and is only 2 functions.

I created this because of the following reasons:
- Using luasocket will produce errors - https://github.com/diegonehab/luasocket/issues/285
- You are unable to send any events to Sentry using luasocket

One caveat of using lua-resty-http is that to use a custom SSL certificate, you will need do the following:
1. Copy CA cert to a directory accessible by Nginx
2. Put the following in your `nginx.conf`
```
lua_ssl_verify_depth 2;
lua_ssl_trusted_certificate <path_to_ca_cert>;
```

I would love to see this pull request merged!