### PR TITLE
Support modern auth-style of Sentry DSN

### DIFF
--- a/raven/senders/luasocket.lua
+++ b/raven/senders/luasocket.lua
@@ -96,4 +96,3 @@ function _M.new(conf)
 end
 
 return _M
-

--- a/raven/senders/ngx.lua
+++ b/raven/senders/ngx.lua
@@ -46,7 +46,7 @@ X-Sentry-Auth: %s
 ]], '\r?\n', '\r\n')
 
 local CALLBACK_DEFAULT_ERRMSG =
-    "failed to onfigure socket (custom callback did not returned a value)"
+    "failed to configure socket (custom callback did not returned a value)"
 
 local function send_msg(self, msg)
     local ok

--- a/raven/util.lua
+++ b/raven/util.lua
@@ -99,14 +99,18 @@ function _M.parse_dsn(dsn, obj)
 
     assert(type(obj) == "table")
 
-    -- '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}'
-    obj.protocol, obj.public_key, obj.secret_key, obj.long_host,
-    obj.path, obj.project_id =
-        string_match(dsn, "^([^:]+)://([^:]+):([^@]+)@([^/]+)(.*/)(.+)$")
+    -- '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'
+    obj.protocol, obj.public_key, obj.long_host, obj.path, obj.project_id =
+        string_match(dsn, "^([^:]+)://([^:]+)@([^/]+)(.*/)(.+)$")
 
-    if obj.protocol and obj.public_key and obj.secret_key and obj.long_host
-        and obj.project_id then
+    if not obj.protocol then
+        -- '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}'
+        obj.protocol, obj.public_key, obj.secret_key, obj.long_host, obj.path,
+        obj.project_id =
+            string_match(dsn, "^([^:]+)://([^:]+):([^@]+)@([^/]+)(.*/)(.+)$")
+    end
 
+    if obj.protocol and obj.public_key and obj.long_host and obj.project_id then
         local host, port, err = parse_host_port(obj.protocol, obj.long_host)
 
         if not host then
@@ -130,6 +134,14 @@ end
 -- @param dsn_object A @{parsed_dsn} table
 -- @return A Sentry authentication string
 function _M.generate_auth_header(dsn_object)
+    if not dsn_object.secret_key then
+        return string_format(
+            "Sentry sentry_version=6, sentry_client=%s, sentry_timestamp=%s, sentry_key=%s",
+            "raven-lua/" .. _VERSION,
+            iso8601(),
+            dsn_object.public_key)
+    end
+
     return string_format(
         "Sentry sentry_version=6, sentry_client=%s, sentry_timestamp=%s, sentry_key=%s, sentry_secret=%s",
         "raven-lua/" .. _VERSION,

--- a/tests/util.lua
+++ b/tests/util.lua
@@ -41,6 +41,19 @@ describe("util functions", function()
         assert_equal(out.long_host, "sentry.example.com:1234")
         assert_equal(out.request_uri, "/api/1/store/")
         assert_equal(out.server, "http://sentry.example.com:1234/api/1/store/")
+
+        -- new auth-style DSN
+        local out = util.parse_dsn("http://public@sentry.example.com/1")
+        assert_equal(out.protocol, "http")
+        assert_equal(out.public_key, "public")
+        assert_equal(out.secret_key, nil)
+        assert_equal(out.host, "sentry.example.com")
+        assert_equal(out.port, 80)
+        assert_equal(out.project_id, "1")
+        -- aux fields
+        assert_equal(out.long_host, "sentry.example.com")
+        assert_equal(out.request_uri, "/api/1/store/")
+        assert_equal(out.server, "http://sentry.example.com:80/api/1/store/")
     end)
 
     test("Auth header generation", function()
@@ -55,6 +68,21 @@ describe("util functions", function()
         assert_equal(params.sentry_version, "6")
         assert_equal(params.sentry_key, "public")
         assert_equal(params.sentry_secret, "secret")
+        assert_type(params.sentry_client, "string")
+        assert_type(params.sentry_timestamp, "string")
+
+        -- new auth-style DSN
+        local dsn = util.parse_dsn("https://public@sentry.example.com/1")
+        local auth = util.generate_auth_header(dsn)
+        assert_equal(auth:match("Sentry .+"), auth)
+        local params = {}
+        for k, v in auth:gmatch("(%S-)=([^,]+)") do
+            params[k] = v
+        end
+
+        assert_equal(params.sentry_version, "6")
+        assert_equal(params.sentry_key, "public")
+        assert_equal(params.sentry_secret, nil)
         assert_type(params.sentry_client, "string")
         assert_type(params.sentry_timestamp, "string")
     end)


### PR DESCRIPTION
I've added support of the modern style of auth in Sentry (without private key).

I think this change don't require to create an issue.