### PR TITLE
Add Support for addition Sentry Fields (Users, Request Data, Environment, Release)

### DIFF
--- a/raven/init.lua
+++ b/raven/init.lua
@@ -136,7 +136,8 @@ function _M.new(conf)
         logger = conf.logger or "root",
         tags = conf.tags or nil,
         extra = conf.extra or nil,
-        environment = conf.environment or nil
+        environment = conf.environment or nil,
+        release = conf.release or nil
     }
 
     return setmetatable(obj, raven_mt)

--- a/raven/init.lua
+++ b/raven/init.lua
@@ -137,7 +137,8 @@ function _M.new(conf)
         tags = conf.tags or nil,
         extra = conf.extra or nil,
         environment = conf.environment or nil,
-        release = conf.release or nil
+        release = conf.release or nil,
+        server_name = conf.server_name or nil
     }
 
     return setmetatable(obj, raven_mt)
@@ -339,8 +340,8 @@ function raven_mt:send_report(json, conf)
     end
 
     json.request  = _M.get_request_data()
-    json.server_name = _M.get_server_name()
-    json.releae = _M.get_release()
+    json.server_name = self.server_name or _M.get_server_name()
+    json.release = self.release or _M.get_release()
 
     local json_str = json_encode(json)
     local ok, err = self.sender:send(json_str)

--- a/raven/init.lua
+++ b/raven/init.lua
@@ -159,6 +159,12 @@ function _M.get_request_data()
     return {}
 end
 
+--- This method can be used to tag a release in Sentry.
+-- Typically you can use it with a commit hash.
+function _M.get_release()
+    return ''
+end
+
 --- This table can be used to tune the message reporting.
 -- @field tags Tags for the message, they will be coalesced with the ones
 --  provided in the @{sentry_conf} table used in the constructor if any. In
@@ -334,6 +340,7 @@ function raven_mt:send_report(json, conf)
 
     json.request  = _M.get_request_data()
     json.server_name = _M.get_server_name()
+    json.releae = _M.get_release()
 
     local json_str = json_encode(json)
     local ok, err = self.sender:send(json_str)

--- a/raven/init.lua
+++ b/raven/init.lua
@@ -136,6 +136,7 @@ function _M.new(conf)
         logger = conf.logger or "root",
         tags = conf.tags or nil,
         extra = conf.extra or nil,
+        environment = conf.environment or nil
     }
 
     return setmetatable(obj, raven_mt)
@@ -146,6 +147,15 @@ end
 -- to override this to something more sensible.
 function _M.get_server_name()
     return "undefined"
+end
+
+--- This method is reponsible to return the `request` field of an event.
+-- The default implementation just returns `{}`, users are encouraged
+-- to override this to something more sensible.
+-- See [Sentry's docs](https://develop.sentry.dev/sdk/event-payloads/request/)
+-- for the list of allowed properties.
+function _M.get_request_data()
+    return {}
 end
 
 --- This table can be used to tune the message reporting.
@@ -296,11 +306,12 @@ function raven_mt:send_report(json, conf)
         end
     end
 
-    json.event_id  = event_id
-    json.timestamp = iso8601()
-    json.level     = self.level
-    json.platform  = "lua"
-    json.logger    = self.logger
+    json.event_id    = event_id
+    json.timestamp   = iso8601()
+    json.level       = self.level
+    json.platform    = "lua"
+    json.logger      = self.logger
+    json.environment = self.environment
 
     if conf then
         json.tags = merge_tables(conf.tags, self.tags)
@@ -309,11 +320,18 @@ function raven_mt:send_report(json, conf)
         if conf.level then
             json.level = conf.level
         end
+        if conf.user then
+            json.user = merge_tables(conf.user, self.user)
+        end
+        if conf.contexts then
+            json.contexts = conf.contexts
+        end
     else
         json.tags = self.tags
         json.extra = self.extra
     end
 
+    json.request  = _M.get_request_data()
     json.server_name = _M.get_server_name()
 
     local json_str = json_encode(json)

--- a/raven/senders/luasocket.lua
+++ b/raven/senders/luasocket.lua
@@ -36,7 +36,7 @@ function mt:send(json_str)
         method = "POST",
         url = self.server,
         headers = {
-            ['Content-Type'] = 'applicaion/json',
+            ['Content-Type'] = 'application/json',
             ['User-Agent'] = "raven-lua-socket/" .. _VERSION,
             ['X-Sentry-Auth'] = generate_auth_header(self),
             ["Content-Length"] = tostring(#json_str),


### PR DESCRIPTION
Sorry this is one big PR. I've been meaning to try to upstream some changes for a while. If there's interest, consider this the start of a conversation — I can try to break this up as necessary. 

Essentially, I've been using raven-lua pretty successfully in a Lapis (OpenResty) project. I've needed to extend this to support a few additional fields more common in traditional user-facing web apps. 

* Adds `environment` as a static property to the event payload, passed in during initialization
* adds`server_name`. Can be passed in or defined with `get_server_name`
* adds `release`. Same deal as above. :)
* Allows `user` and `contexts` tables to be passed to `send_report`
* Now includes a default version of `get_request_data` which was contributed to my fork by danifbento
* Also fixes a small typo. :)